### PR TITLE
Missing gst-libav issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ For more see [IPTV Project](https://github.com/iptv-org/iptv).
 - gstreamer (1.20.3+)
 - GNU Make (4.3+)
 - gst-plugins-bad
-
+- gst-libav
+- 
 ## Installation
 ### For Debian and Ubuntu+
 
@@ -41,6 +42,7 @@ $ ./iptv-desktop
 
 ```sh
 $ sudo pacman -S gst-plugins-bad
+$ sudo pacman -Syu gst-libav
 $ git clone https://github.com/0x0is1/iptv-desktop
 $ cd iptv-desktop/src
 $ qmake iptv-desktop.pro


### PR DESCRIPTION
#2 suggests there is some issues triggered due to missing gst-libav-1.22.7-1-x86_64 binary. Added process to install it manually before build